### PR TITLE
Added a search box that filters the custom editor by key, value or comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It offers the following features;
 - Adding a new resx data.
 - Editing an existing resx data.
 - Deleting an existing resx data.
+- Searching by key, value or comment to filter down a large resx file. `Ctrl+F` (`Cmd+F` on macOS) focuses the search box and `Esc` clears it.
 - Checks for resx data with duplicate keys and shows error if exists.
 - To and Fro updates between Text document and ResxEditors as soon as typed valid resx data.
 - To and fro updates Text document and ResxEditors when Save triggered on either.

--- a/src/resxEditor.ts
+++ b/src/resxEditor.ts
@@ -47,6 +47,13 @@ export class ResxEditor {
             <img src="${faSortAtoZ}" alt="Sort Icon" class="icon filter-fefefe">Sort By Keys
         </button>
         <p id="errorBlock" class="error-block"></p>
+        <!-- Last in the toolbar, and given a full-width flex basis, so it takes a row of its own under the buttons. -->
+        <div class="search-section">
+            <input id="searchInput" class="search-input" type="search"
+                   placeholder="Search key, value or comment"
+                   aria-label="Search key, value or comment" />
+            <span id="searchStatus" class="search-status"></span>
+        </div>
     </div>
 
     <table id="tbl">

--- a/src/webpanelScript.ts
+++ b/src/webpanelScript.ts
@@ -34,6 +34,20 @@ const switchToTextEditorButton = "switchToTextEditorButton";
 const message = "message";
 const none = "none";
 const namespaceSpan = "namespaceSpan";
+const searchInput = "searchInput";
+const searchStatus = "searchStatus";
+const searchSummary = (matchCount: number, total: number) => `Showing ${matchCount} of ${total}`;
+const keydown = "keydown";
+const escapeKey = "Escape";
+const findKey = "f";
+const filteredOutClass = "filtered-out";
+const altRowClass = "alt-row";
+const stickyToolbarSelector = ".sticky-div";
+const stickyToolbarHeightProperty = "--sticky-toolbar-height";
+const macUserAgentMarker = "Mac";
+const macFindShortcut = "⌘F";
+const findShortcut = "Ctrl+F";
+const searchTooltip = (shortcut: string) => `Search key, value or comment (${shortcut} to focus, Esc to clear)`;
 const documentUpdateDelayInMilliseconds = 300;
 
 function logToConsole(text: string) {
@@ -47,6 +61,8 @@ function logToConsole(text: string) {
 
 	const table = document.querySelector(tbody)!;
 	const errorContainer = document.getElementById(errorBlock);
+	const searchInputElement = getInput(searchInput);
+	const searchStatusElement = document.getElementById(searchStatus);
 	let pendingUpdateHandle: ReturnType<typeof setTimeout> | undefined;
 
 	function showError(errorMessage: string) {
@@ -201,6 +217,55 @@ function logToConsole(text: string) {
 	function renderEntries() {
 		table.innerHTML = emptyString;
 		currentEntries.forEach((entry, index) => table.appendChild(createRow(entry, index)));
+		applyFilter();
+	}
+
+	function entryMatches(entry: ResxEntry, query: string): boolean {
+		return entry.key.toLowerCase().includes(query)
+			|| entry.value.toLowerCase().includes(query)
+			|| (entry.comment ?? emptyString).toLowerCase().includes(query);
+	}
+
+	/*
+	 * Non-matching rows are hidden where they are rather than dropped from the
+	 * table. A row's id is its index in currentEntries, so rendering only the
+	 * matches would renumber the survivors and send every later edit and delete
+	 * to the wrong entry. Striping is assigned here for the same reason:
+	 * nth-child still counts a hidden row, so CSS alone cannot alternate the
+	 * rows that remain visible.
+	 */
+	function applyFilter() {
+		const query = (searchInputElement?.value ?? emptyString).trim().toLowerCase();
+		let visibleCount = 0;
+
+		currentEntries.forEach((entry, index) => {
+			const child = table.children[index];
+			const row = child instanceof HTMLElement ? child : undefined;
+			if (row === undefined) {
+				return;
+			}
+
+			const isMatch = query.length === 0 || entryMatches(entry, query);
+			row.classList.toggle(filteredOutClass, isMatch === false);
+			row.classList.toggle(altRowClass, isMatch && visibleCount % 2 === 1);
+			if (isMatch) {
+				visibleCount++;
+			}
+		});
+
+		if (searchStatusElement !== null) {
+			searchStatusElement.textContent = query.length === 0
+				? emptyString
+				: searchSummary(visibleCount, currentEntries.length);
+		}
+	}
+
+	function clearSearch() {
+		if (searchInputElement === undefined) {
+			return;
+		}
+
+		searchInputElement.value = emptyString;
 	}
 
 	function deleteEvent(event: MouseEvent) {
@@ -266,10 +331,44 @@ function logToConsole(text: string) {
 		});
 	}
 
+	if (searchInputElement !== undefined) {
+		/*
+		 * The shortcut is named on hover rather than in the placeholder, which has
+		 * to say what the box searches. It is spelled for the platform because the
+		 * handler below accepts either modifier, so Ctrl+F on a Mac would be a lie.
+		 */
+		searchInputElement.title = searchTooltip(navigator.userAgent.includes(macUserAgentMarker)
+			? macFindShortcut
+			: findShortcut);
+		searchInputElement.addEventListener(input, applyFilter, false);
+		searchInputElement.addEventListener(keydown, event => {
+			if (event.key === escapeKey) {
+				clearSearch();
+				applyFilter();
+			}
+		}, false);
+
+		/*
+		 * Ctrl+F is what anyone will reach for first, and nothing else claims it
+		 * here: VS Code's webview find widget is opt-in and would be useless even
+		 * if it were on, because it drives Chromium's find-in-page, which does not
+		 * look inside <input> values - and every resx field is an input.
+		 */
+		document.addEventListener(keydown, event => {
+			if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === findKey) {
+				event.preventDefault();
+				searchInputElement.focus();
+				searchInputElement.select();
+			}
+		}, false);
+	}
+
 	const addButtonElement = document.getElementById(addButton);
 	if (addButtonElement !== null) {
 		addButtonElement.addEventListener(click, () => {
 			logToConsole("addButton clicked");
+			// The new row is empty, so an active filter would hide the row that was just asked for.
+			clearSearch();
 			currentEntries.push({ key: emptyString, value: emptyString });
 			renderEntries();
 
@@ -289,6 +388,22 @@ function logToConsole(text: string) {
 				WebpanelPostMessageKind.SortByKeys,
 				JSON.stringify(emptyString)));
 		});
+	}
+
+	/*
+	 * The column headers stick directly under the toolbar, so they need its
+	 * height. It is not a constant: the toolbar wraps, so the height changes with
+	 * the panel width. Publishing the measured value replaces a hardcoded 62px
+	 * that was only ever correct for a single-row toolbar.
+	 */
+	const stickyToolbar = document.querySelector(stickyToolbarSelector);
+	if (stickyToolbar !== null) {
+		const publishToolbarHeight = () => document.documentElement.style.setProperty(
+			stickyToolbarHeightProperty,
+			`${stickyToolbar.getBoundingClientRect().height}px`);
+
+		publishToolbarHeight();
+		new ResizeObserver(publishToolbarHeight).observe(stickyToolbar);
 	}
 
 	// A hidden webview is torn down, so whatever is still queued has to go now.

--- a/styles/webpanel.css
+++ b/styles/webpanel.css
@@ -45,17 +45,25 @@ th {
   position: sticky;
   position: -webkit-sticky;
   padding: -chrome-sticky;
-  top: 62px;
-  margin-top: 62px;
+  /* Measured and published by webpanelScript; the fallback is a one-row toolbar. */
+  top: var(--sticky-toolbar-height, 62px);
   box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
   background-color: var(--vscode-sideBar-background);
   text-align: center;
   padding: 15px 15px;
 }
 
-tr:nth-child(even) {
+/*
+ * Striping is a class rather than :nth-child(even) because a filtered-out row
+ * still counts as a child, which would leave gaps in the alternating colour.
+ * applyFilter in webpanelScript assigns it over the visible rows instead.
+ */
+tr.alt-row {
   background-color: var(--vscode-sideBar-background);
-  padding: 0;
+}
+
+tr.filtered-out {
+  display: none;
 }
 
 input {
@@ -138,6 +146,62 @@ p {
   font-size: 14px;
   margin: 0;
   flex-grow: 1;
+}
+
+/*
+ * flex-basis of 100% drops the search row onto its own line under the buttons,
+ * so the box gets the editor's full width instead of fighting four labelled
+ * buttons and the namespace block for it.
+ */
+.search-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 100%;
+}
+
+/*
+ * The bare `input` rule above is written for the borderless cells inside the
+ * table - transparent, 95% wide, full height - so this box has to override
+ * every one of those declarations rather than only the ones it wants changed.
+ */
+.search-input {
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: 4px;
+  flex: 1;
+  /* Without this a long placeholder sets the min-content width and overflows the row. */
+  min-width: 0;
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 8px 10px;
+  font-size: 16px;
+  font-family: inherit;
+}
+
+/* Ellipsis rather than a placeholder cut off mid-word if the box is ever narrowed. */
+.search-input::placeholder {
+  color: var(--vscode-input-placeholderForeground);
+  text-overflow: ellipsis;
+}
+
+.search-input:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+/* The native clear button is drawn in a fixed colour that disappears on dark themes. */
+.search-input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.search-status {
+  color: var(--vscode-descriptionForeground);
+  font-size: 13px;
+  white-space: nowrap;
 }
 
 .namespace-section {


### PR DESCRIPTION
A search box on its own full-width row filters rows by key,
value or comment, with a `Showing 3 of 240` counter. Ctrl+F (Cmd+F on macOS)
focuses it, Esc clears it. Webview-side only — no new message kind.

Also fixes the sticky column headers sliding under the toolbar when it wrapped:
`th { top: 62px }` assumed a one-row toolbar and is now
`var(--sticky-toolbar-height, 62px)`, measured by a `ResizeObserver`.