### PR TITLE
Fixed the combined panel's dead restore tab, case-sensitive sibling matching and stale sibling context key

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,23 +1,53 @@
+import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
-    {
-        ignores: [
-            "out/**",
-            "dist/**",
-            "webpack.config.js",
-            "src/test/**"
-        ]
-    },
+export default defineConfig([
+    globalIgnores([
+        "out/**",
+        "dist/**",
+        "webpack.config.js",
+        // ESM, run straight off the .ts sources by Node; outside tsconfig.json too.
+        "src/test/**"
+    ]),
     {
         files: ["src/**/*.ts"],
         extends: [tseslint.configs.base],
         rules: {
-            "@typescript-eslint/naming-convention": "warn",
+            /*
+             * The defaults, plus PascalCase enum members - what the TypeScript
+             * handbook, the compiler and the VS Code API all use. Restated in
+             * full because options replace the default set rather than add to it.
+             */
+            "@typescript-eslint/naming-convention": ["warn",
+                {
+                    selector: "default",
+                    format: ["camelCase"],
+                    leadingUnderscore: "allow",
+                    trailingUnderscore: "allow"
+                },
+                {
+                    selector: "import",
+                    format: ["camelCase", "PascalCase"]
+                },
+                {
+                    selector: "variable",
+                    format: ["camelCase", "UPPER_CASE"],
+                    leadingUnderscore: "allow",
+                    trailingUnderscore: "allow"
+                },
+                {
+                    selector: "typeLike",
+                    format: ["PascalCase"]
+                },
+                {
+                    selector: "enumMember",
+                    format: ["PascalCase"]
+                }
+            ],
             "curly": "warn",
             "eqeqeq": "warn",
             "no-throw-literal": "warn",
             "semi": "warn"
         }
     }
-);
+]);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "Other"
     ],
     "activationEvents": [
-        "workspaceContains:**/*.resx"
+        "workspaceContains:**/*.resx",
+        "onWebviewPanel:resxpress.combinedEditor"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -107,6 +108,11 @@
                 }
             ],
             "explorer/context": [
+                {
+                    "command": "resxpress.combinededitor",
+                    "group": "3_preview",
+                    "when": "resourceExtname == .resx"
+                },
                 {
                     "command": "resxpress.setNameSpace",
                     "group": "3_preview",

--- a/src/combinedPanelScript.ts
+++ b/src/combinedPanelScript.ts
@@ -9,6 +9,7 @@ import { WebpanelPostMessage } from "./webpanelPostMessage";
 const resxpressCombinedPanel = "resxpress.combinedPanel";
 const tbody = "tbody";
 const tableHead = "tableHead";
+const tableScroll = "tableScroll";
 const errorBlock = "errorBlock";
 const keyField = "key";
 const valueField = "value";
@@ -62,6 +63,7 @@ const macUserAgentMarker = "Mac";
 const macFindShortcut = "⌘F";
 const findShortcut = "Ctrl+F";
 const searchTooltip = (shortcut: string) => `Search key, value or comment (${shortcut} to focus, Esc to clear)`;
+const pixels = (length: number) => `${length}px`;
 const documentUpdateDelayInMilliseconds = 300;
 
 function logToConsole(logText: string) {
@@ -79,10 +81,12 @@ function logToConsole(logText: string) {
     const searchInputElement = getInput(searchInput);
     const searchStatusElement = document.getElementById(searchStatus);
     const commentModeElement = document.getElementById(commentModeButton);
+    const scrollContainer = document.getElementById(tableScroll);
 
     let currentColumns: CombinedColumn[] = [];
     let currentEntries: CombinedEntry[] = [];
     let unifiedComments = true;
+    let groupUri: string | undefined;
     let pendingUpdateHandle: ReturnType<typeof setTimeout> | undefined;
 
     function showError(errorMessage: string) {
@@ -372,6 +376,26 @@ function logToConsole(logText: string) {
         currentEntries.forEach((entry, index) => body.appendChild(createRow(entry, index)));
         currentEntries.forEach((_entry, index) => markMissingCells(index));
         applyFilter();
+        reserveStickyEdges();
+    }
+
+    /*
+     * Scroll-into-view measures the scrollport, not what the sticky Key column
+     * and header row paint over it, so tabbing parks the next cell underneath
+     * them. Scroll padding shrinks the region it will call "in view";
+     * remeasured every render because the Key column is sized by its content.
+     */
+    function reserveStickyEdges() {
+        if (scrollContainer === null || head === null) {
+            return;
+        }
+
+        const keyHeaderCell = head.querySelector(`${th}.${keyColumnClass}`);
+        if (keyHeaderCell instanceof HTMLElement) {
+            scrollContainer.style.scrollPaddingLeft = pixels(keyHeaderCell.offsetWidth);
+        }
+
+        scrollContainer.style.scrollPaddingTop = pixels(head.offsetHeight);
     }
 
     function entryMatches(entry: CombinedEntry, query: string): boolean {
@@ -437,8 +461,16 @@ function logToConsole(logText: string) {
     function setCommentMode(isUnified: boolean) {
         unifiedComments = isUnified;
         updateCommentModeButton();
-        vscode.setState({ unifiedComments: unifiedComments });
+        persistState();
         renderTable();
+    }
+
+    /*
+     * One writer, because setState replaces the whole object: a comment mode
+     * saved on its own would drop the uri the serializer restores from.
+     */
+    function persistState() {
+        vscode.setState({ unifiedComments: unifiedComments, groupUri: groupUri });
     }
 
     function updateCommentModeButton() {
@@ -562,11 +594,21 @@ function logToConsole(logText: string) {
         if (messageData.type === WebpanelPostMessageKind.UpdateCombinedPanel) {
             updatePanelWebContent(messageData.text);
         }
+
+        if (messageData.type === WebpanelPostMessageKind.CombinedPanelIdentity) {
+            groupUri = JSON.parse(messageData.text);
+            persistState();
+        }
     });
 
     const state = vscode.getState();
     if (state?.unifiedComments !== undefined) {
         unifiedComments = state.unifiedComments === true;
+    }
+
+    // Held until the host says otherwise, so a toggle before then does not drop it.
+    if (typeof state?.groupUri === "string") {
+        groupUri = state.groupUri;
     }
 
     updateCommentModeButton();

--- a/src/combinedResxPanel.ts
+++ b/src/combinedResxPanel.ts
@@ -17,6 +17,7 @@ import { getNonce } from "./util";
 import { WebpanelPostMessageKind } from "./webpanelMessageKind";
 import { WebpanelPostMessage } from "./webpanelPostMessage";
 
+const resxInSameFolder = "*.resx";
 const panelTitle = (baseName: string) => `${baseName} - All Languages`;
 const unparseableFile = (fileName: string) => `${fileName} is not valid resx, so the combined panel is not being updated`;
 const skippedWrite = (fileName: string) => `${fileName} is not valid resx, so it was left alone`;
@@ -37,8 +38,10 @@ export class CombinedResxPanel {
     private static readonly openPanels = new Map<string, CombinedResxPanel>();
 
     private readonly panel: vscode.WebviewPanel;
-    private readonly group: ResxGroup;
     private readonly disposables: vscode.Disposable[] = [];
+
+    /* Not readonly: a culture file added or removed while the panel is open re-resolves it. */
+    private group: ResxGroup;
 
     /** Set while our own edits are being applied, so they are not echoed back as a repaint. */
     private isWritingEdits = false;
@@ -63,6 +66,7 @@ export class CombinedResxPanel {
             Logger.instance.info(`${nameof(CombinedResxPanel)}: ${message.type}`);
             switch (message.type) {
                 case WebpanelPostMessageKind.Ready:
+                    this.postIdentity();
                     this.enqueue(() => this.pushToWebview());
                     break;
                 case WebpanelPostMessageKind.TriggerCombinedUpdate:
@@ -91,11 +95,58 @@ export class CombinedResxPanel {
                 void this.pushToWebview();
             }
         }, null, this.disposables);
+
+        this.watchForCultureChanges();
     }
 
-    public static async createOrShow(extensionUri: vscode.Uri, uri: vscode.Uri): Promise<void> {
-        const group = await ResxGroup.resolve(uri);
+    /*
+     * A watcher rather than `workspace.onDidCreateFiles`, which reports only
+     * what VS Code itself did - a file written by a build never reaches it.
+     */
+    private watchForCultureChanges(): void {
+        const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(this.group.directory,
+                                                                                            resxInSameFolder),
+                                                                 false,
+                                                                 true,
+                                                                 false);
 
+        watcher.onDidCreate(() => this.enqueue(() => this.regroup()), null, this.disposables);
+        watcher.onDidDelete(() => this.enqueue(() => this.regroup()), null, this.disposables);
+        this.disposables.push(watcher);
+    }
+
+    /**
+     * Re-resolves the group, repainting if the cultures moved. Re-keys
+     * `openPanels` with it: a neutral file appearing changes the base name,
+     * and a stale key would let a second panel open for the same resource.
+     */
+    private async regroup(): Promise<void> {
+        const anchor = this.group.anchorUri;
+        if (anchor === undefined) {
+            return;
+        }
+
+        const regrouped = await ResxGroup.resolve(anchor);
+        if (JSON.stringify(regrouped.cultures) === JSON.stringify(this.group.cultures)) {
+            return;
+        }
+
+        Logger.instance.info(`${nameof(CombinedResxPanel)}: cultures are now ${regrouped.cultures.join(", ")}`);
+
+        CombinedResxPanel.openPanels.delete(this.group.key);
+        this.group = regrouped;
+        CombinedResxPanel.openPanels.set(this.group.key, this);
+
+        this.panel.title = panelTitle(this.group.baseName);
+        this.postIdentity();
+        await this.pushToWebview();
+    }
+
+    /**
+     * The group is resolved by the caller: whether a resource with a single
+     * language is worth a panel depends on where the command came from.
+     */
+    public static async createOrShow(extensionUri: vscode.Uri, group: ResxGroup): Promise<void> {
         const existing = CombinedResxPanel.openPanels.get(group.key);
         if (existing !== undefined) {
             existing.panel.reveal(existing.panel.viewColumn);
@@ -113,14 +164,41 @@ export class CombinedResxPanel {
         const panel = vscode.window.createWebviewPanel(CombinedResxPanel.viewType,
                                                        panelTitle(group.baseName),
                                                        vscode.ViewColumn.Active,
-                                                       {
-                                                           enableScripts: true,
-                                                           enableForms: true,
-                                                           localResourceRoots: [vscode.Uri.joinPath(extensionUri, "styles"),
-                                                                                vscode.Uri.joinPath(extensionUri, "out")]
-                                                       });
+                                                       CombinedResxPanel.webviewOptions(extensionUri));
 
         CombinedResxPanel.openPanels.set(group.key, new CombinedResxPanel(panel, group, extensionUri));
+    }
+
+    /**
+     * Takes over a panel VS Code restored after a reload. Only the group's uri
+     * comes out of the webview's state - the documents hold the table.
+     *
+     * @throws when the uri no longer names a resx file.
+     */
+    public static async revive(extensionUri: vscode.Uri, panel: vscode.WebviewPanel, uri: vscode.Uri): Promise<void> {
+        const group = await ResxGroup.resolve(uri);
+
+        const existing = CombinedResxPanel.openPanels.get(group.key);
+        if (existing !== undefined) {
+            panel.dispose();
+            existing.panel.reveal(existing.panel.viewColumn);
+            return;
+        }
+
+        // A restored panel keeps its title, but not the options it was created with.
+        panel.webview.options = CombinedResxPanel.webviewOptions(extensionUri);
+        panel.title = panelTitle(group.baseName);
+
+        CombinedResxPanel.openPanels.set(group.key, new CombinedResxPanel(panel, group, extensionUri));
+    }
+
+    private static webviewOptions(extensionUri: vscode.Uri): vscode.WebviewOptions {
+        return {
+            enableScripts: true,
+            enableForms: true,
+            localResourceRoots: [vscode.Uri.joinPath(extensionUri, "styles"),
+                                 vscode.Uri.joinPath(extensionUri, "out")]
+        };
     }
 
     private enqueue(work: () => Promise<void>): void {
@@ -205,6 +283,20 @@ export class CombinedResxPanel {
         }
 
         await this.pushToWebview();
+    }
+
+    /*
+     * What the webview persists for restore. Sent on Ready rather than carried
+     * on the payload, because a file that does not parse produces no payload.
+     */
+    private postIdentity(): void {
+        const anchor = this.group.anchorUri;
+        if (anchor === undefined) {
+            return;
+        }
+
+        this.panel.webview.postMessage(new WebpanelPostMessage(WebpanelPostMessageKind.CombinedPanelIdentity,
+                                                               JSON.stringify(anchor.toString())));
     }
 
     private async pushToWebview(): Promise<void> {
@@ -334,7 +426,7 @@ export class CombinedResxPanel {
         </div>
     </div>
 
-    <div class="table-scroll">
+    <div id="tableScroll" class="table-scroll">
         <table id="tbl">
             <thead id="tableHead">
             </thead>

--- a/src/combinedResxPanelSerializer.ts
+++ b/src/combinedResxPanelSerializer.ts
@@ -1,0 +1,59 @@
+import * as vscode from "vscode";
+import { CombinedResxPanel } from "./combinedResxPanel";
+import { Logger } from "./logger";
+
+/**
+ * Brings the combined panel back after a reload. With nothing claiming the view
+ * type, VS Code restores the tab and finds nobody to fill it.
+ */
+export class CombinedResxPanelSerializer implements vscode.WebviewPanelSerializer {
+
+    private readonly extensionUri: vscode.Uri;
+
+    constructor(extensionUri: vscode.Uri) {
+        this.extensionUri = extensionUri;
+    }
+
+    public static register(context: vscode.ExtensionContext): vscode.Disposable {
+        return vscode.window.registerWebviewPanelSerializer(CombinedResxPanel.viewType,
+                                                            new CombinedResxPanelSerializer(context.extensionUri));
+    }
+
+    public async deserializeWebviewPanel(panel: vscode.WebviewPanel, state: unknown): Promise<void> {
+        const groupUri = CombinedResxPanelSerializer.groupUriFrom(state);
+        if (groupUri === undefined) {
+            panel.dispose();
+            return;
+        }
+
+        try {
+            await CombinedResxPanel.revive(this.extensionUri, panel, groupUri);
+        }
+        catch (error) {
+            /*
+             * Renamed or deleted while the window was closed, or state left by
+             * an older version. Closing the tab is the honest outcome.
+             */
+            if (error instanceof Error) {
+                Logger.instance.warning(error.message);
+            }
+
+            panel.dispose();
+        }
+    }
+
+    /* Written by the webview and outlives an upgrade, so it is read, not cast. */
+    private static groupUriFrom(state: unknown): vscode.Uri | undefined {
+        const groupUri = (state as { groupUri?: unknown } | null | undefined)?.groupUri;
+        if (typeof groupUri !== "string" || groupUri.length === 0) {
+            return undefined;
+        }
+
+        try {
+            return vscode.Uri.parse(groupUri, true);
+        }
+        catch {
+            return undefined;
+        }
+    }
+}

--- a/src/commandId.ts
+++ b/src/commandId.ts
@@ -1,0 +1,15 @@
+import { Constants } from "./constants";
+
+/**
+ * The command ids this extension registers, spelled out again in package.json
+ * under `contributes.commands` - except `resxeditor`, which nothing can reach.
+ */
+export class CommandId {
+    public static readonly resxpreview = `${Constants.resxpress}.resxpreview`;
+    public static readonly newpreview = `${Constants.resxpress}.newpreview`;
+    public static readonly sortbykeys = `${Constants.resxpress}.sortbykeys`;
+    public static readonly setNameSpace = `${Constants.resxpress}.setNameSpace`;
+    public static readonly createResxFile = `${Constants.resxpress}.createResxFile`;
+    public static readonly resxeditor = `${Constants.resxpress}.resxeditor`;
+    public static readonly combinedEditor = `${Constants.resxpress}.combinededitor`;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,21 +20,4 @@ export class Constants {
      * can hide "Edit All Languages" for a resource that has only one file.
      */
     public static readonly hasCultureSiblingsContext = `${this.resxpress}.hasCultureSiblings`;
-
-    static Commands = class {
-        public static readonly resxpreview = `${Constants.resxpress}.resxpreview`;
-        public static readonly newpreview = `${Constants.resxpress}.newpreview`;
-        public static readonly sortbykeys = `${Constants.resxpress}.sortbykeys`;
-        public static readonly setNameSpace = `${Constants.resxpress}.setNameSpace`;
-        public static readonly createResxFile = `${Constants.resxpress}.createResxFile`;
-        public static readonly resxeditor = `${Constants.resxpress}.resxeditor`;
-        public static readonly combinedEditor = `${Constants.resxpress}.combinededitor`;
-    };
-
-    static Configuration = class {
-        public static readonly generateStronglyTypedResourceClassOnSave = "generateStronglyTypedResourceClassOnSave";
-        public static readonly useFileScopedNamespace = "useFileScopedNamespace";
-        public static readonly indentSpaceLength = "indentSpaceLength";
-        public static readonly enableLocalLogs = "enableLocalLogs";
-    };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,19 +2,26 @@ import * as vscode from "vscode";
 
 import { promises as fsPromises } from "fs";
 import { CombinedResxPanel } from "./combinedResxPanel";
+import { CombinedResxPanelSerializer } from "./combinedResxPanelSerializer";
 import { PreviewEditPanel } from "./previewEditPanel";
 import * as path from "path";
 import { ResxEditorProvider } from "./resxEditorProvider";
 import { NotificationService } from "./notificationService";
 import { FileHelper } from "./fileHelper";
 import { TextInputBoxOptions } from "./textInputBoxOptions";
+import { CommandId } from "./commandId";
 import { Constants, emptyString } from "./constants";
+import { SettingKey } from "./settingKey";
 import { ResxDocumentWriter } from "./resxDocumentWriter";
 import type { ResxEntry } from "./resxEntry";
 import { ResxFile } from "./resxFile";
+import { ResxGroup } from "./resxGroup";
 import { Settings } from "./settings";
 import { Logger } from "./logger";
 
+
+const nothingToCombine = (fileName: string, baseName: string) =>
+	`${fileName} is the only language file for this resource. Add one named ${baseName}.<culture>.resx - ${baseName}.de.resx, say - and Edit All Languages will show a column for it.`;
 
 let currentContext: vscode.ExtensionContext;
 
@@ -35,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	vscode.workspace.onDidChangeConfiguration(loadConfiguration);
 
-	context.subscriptions.push(vscode.commands.registerTextEditorCommand(Constants.Commands.resxpreview,
+	context.subscriptions.push(vscode.commands.registerTextEditorCommand(CommandId.resxpreview,
 		async () => {
 			vscode.window.withProgress({
 				location: vscode.ProgressLocation.Notification,
@@ -49,7 +56,7 @@ export function activate(context: vscode.ExtensionContext) {
 			);
 		}));
 
-	context.subscriptions.push(vscode.commands.registerTextEditorCommand(Constants.Commands.sortbykeys,
+	context.subscriptions.push(vscode.commands.registerTextEditorCommand(CommandId.sortbykeys,
 		async (editor) => {
 			if (!editor.document) {
 				return;
@@ -64,7 +71,7 @@ export function activate(context: vscode.ExtensionContext) {
 			});
 		}));
 
-	context.subscriptions.push(vscode.commands.registerTextEditorCommand(Constants.Commands.newpreview,
+	context.subscriptions.push(vscode.commands.registerTextEditorCommand(CommandId.newpreview,
 		async () => {
 			vscode.window.withProgress({
 				location: vscode.ProgressLocation.Notification,
@@ -76,10 +83,10 @@ export function activate(context: vscode.ExtensionContext) {
 			});
 		}));
 
-	context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.setNameSpace, async (document: vscode.TextDocument) => await setNewNamespace(document)));
-	context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.createResxFile, async (uri: vscode.Uri) => await createResxFile(uri)));
-	context.subscriptions.push(vscode.commands.registerTextEditorCommand(Constants.Commands.resxeditor, async () => await newPreview()));
-	context.subscriptions.push(vscode.commands.registerCommand(Constants.Commands.combinedEditor, async (uri?: vscode.Uri) => await openCombinedEditor(context, uri)));
+	context.subscriptions.push(vscode.commands.registerCommand(CommandId.setNameSpace, async (document: vscode.TextDocument) => await setNewNamespace(document)));
+	context.subscriptions.push(vscode.commands.registerCommand(CommandId.createResxFile, async (uri: vscode.Uri) => await createResxFile(uri)));
+	context.subscriptions.push(vscode.commands.registerTextEditorCommand(CommandId.resxeditor, async () => await newPreview()));
+	context.subscriptions.push(vscode.commands.registerCommand(CommandId.combinedEditor, async (uri?: vscode.Uri) => await openCombinedEditor(context, uri)));
 
 	/*
 	 * "Edit All Languages" is only offered for a resource that actually has more
@@ -94,6 +101,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.workspace.onDidDeleteFiles(() => void updateCultureSiblingsContext()));
 	context.subscriptions.push(vscode.workspace.onDidRenameFiles(() => void updateCultureSiblingsContext()));
 	void updateCultureSiblingsContext();
+
+	context.subscriptions.push(CombinedResxPanelSerializer.register(context));
 
 	context.subscriptions.push(ResxEditorProvider.register(context));
 
@@ -119,10 +128,21 @@ export function activate(context: vscode.ExtensionContext) {
 	Logger.instance.info(`Extension ${context.extension.id} activated`);
 }
 
+/*
+ * Six events feed this and none of them wait, so listings overlap. Without the
+ * token the slowest wins and the key describes a file the user has left.
+ */
+let latestCultureSiblingsRequest = 0;
+
 async function updateCultureSiblingsContext() {
+	const request = ++latestCultureSiblingsRequest;
 	const uri = resolveResxUri();
 	const isResx = uri !== undefined && uri.path.toLowerCase().endsWith(".resx");
 	const hasCultureSiblings = isResx && await ResxEditorProvider.hasCultureSiblings(uri);
+	if (request !== latestCultureSiblingsRequest) {
+		return;
+	}
+
 	await vscode.commands.executeCommand("setContext", Constants.hasCultureSiblingsContext, hasCultureSiblings);
 }
 
@@ -134,7 +154,17 @@ async function openCombinedEditor(context: vscode.ExtensionContext, uri?: vscode
 			return;
 		}
 
-		await CombinedResxPanel.createOrShow(context.extensionUri, resxUri);
+		/*
+		 * The explorer entry cannot be narrower - a context key is one value for
+		 * the whole window, not one per row - so lone files are answered here.
+		 */
+		const group = await ResxGroup.resolve(resxUri);
+		if (group.cultures.length < 2) {
+			vscode.window.showInformationMessage(nothingToCombine(group.fileNameFor(group.cultures[0]), group.baseName));
+			return;
+		}
+
+		await CombinedResxPanel.createOrShow(context.extensionUri, group);
 	}
 	catch (error) {
 		var errorMessage = emptyString;
@@ -174,10 +204,10 @@ function resolveResxUri(uri?: vscode.Uri): vscode.Uri | undefined {
 
 function loadConfiguration() {
 	let resxConfig = vscode.workspace.getConfiguration(`${Constants.resxpress}.${Constants.configuration}`);
-	Settings.shouldGenerateStronglyTypedResourceClassOnSave = resxConfig.get<boolean>(Constants.Configuration.generateStronglyTypedResourceClassOnSave) ?? false;
-	Settings.shouldUseFileScopedNamespace = resxConfig.get<boolean>(Constants.Configuration.useFileScopedNamespace) ?? true;
-	Settings.indentSpaceLength = resxConfig.get<number>(Constants.Configuration.indentSpaceLength) ?? 4;
-	Settings.enableLocalLogs = resxConfig.get<boolean>(Constants.Configuration.enableLocalLogs) ?? false;
+	Settings.shouldGenerateStronglyTypedResourceClassOnSave = resxConfig.get<boolean>(SettingKey.generateStronglyTypedResourceClassOnSave) ?? false;
+	Settings.shouldUseFileScopedNamespace = resxConfig.get<boolean>(SettingKey.useFileScopedNamespace) ?? true;
+	Settings.indentSpaceLength = resxConfig.get<number>(SettingKey.indentSpaceLength) ?? 4;
+	Settings.enableLocalLogs = resxConfig.get<boolean>(SettingKey.enableLocalLogs) ?? false;
 	Logger.instance.setIsEnabled(Settings.enableLocalLogs);
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,10 +11,10 @@ export interface ILogger {
 }
 
 enum LogLevel {
-    error = "ERROR",
-    warning = "WARNING",
-    info = "INFO",
-    debug = "DEBUG",
+    Error = "ERROR",
+    Warning = "WARNING",
+    Info = "INFO",
+    Debug = "DEBUG",
 }
 
 function isString(value: unknown): value is string {
@@ -47,20 +47,20 @@ export class Logger implements ILogger {
 
     public error(error: Error): void {
         if (error !== null) {
-            this.log(LogLevel.error, error.stack ?? `${error.name} : ${error.message}`);
+            this.log(LogLevel.Error, error.stack ?? `${error.name} : ${error.message}`);
         }
     }
 
     public info(message: string): void {
-        this.log(LogLevel.info, message);
+        this.log(LogLevel.Info, message);
     }
 
     public debug(message: string): void {
-        this.log(LogLevel.debug, message);
+        this.log(LogLevel.Debug, message);
     }
 
     public warning(message: string): void {
-        this.log(LogLevel.warning, message);
+        this.log(LogLevel.Warning, message);
     }
 
     private log(logLevel: LogLevel, message: string, data?: unknown): void {

--- a/src/resxEditorProvider.ts
+++ b/src/resxEditorProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { CommandId } from "./commandId";
 import { Constants, emptyString } from "./constants";
 import { setNewNamespace, sortByKeys } from "./extension";
 import { FileHelper } from "./fileHelper";
@@ -81,7 +82,7 @@ export class ResxEditorProvider implements vscode.CustomTextEditorProvider {
                     updateWebview();
                     break;
                 case WebpanelPostMessageKind.OpenAllLanguages:
-                    await vscode.commands.executeCommand(Constants.Commands.combinedEditor, document.uri);
+                    await vscode.commands.executeCommand(CommandId.combinedEditor, document.uri);
                     break;
             }
         });

--- a/src/resxFileName.ts
+++ b/src/resxFileName.ts
@@ -67,6 +67,39 @@ export class ResxFileName {
         return culture.length === 0 ? neutralLabel : culture;
     }
 
+    /**
+     * Whether two base names name the same resource. Folded because `fs.stat`
+     * is: comparing exactly loses the Default column, and says nothing.
+     */
+    public static sameBaseName(first: string, second: string): boolean {
+        return first.toLowerCase() === second.toLowerCase();
+    }
+
+    /** Folded like the base name: `fr-CA` and `fr-ca` are one culture to .NET. */
+    public static cultureKey(culture: string): string {
+        return culture.toLowerCase();
+    }
+
+    /**
+     * Orders two spellings of one file name, best first: the one the group was
+     * resolved from, then ordinal, so a listing's order never decides it.
+     */
+    public static compareSpellings(first: string, second: string, resolvedFrom: string): number {
+        if (first === second) {
+            return 0;
+        }
+
+        if (first === resolvedFrom) {
+            return -1;
+        }
+
+        if (second === resolvedFrom) {
+            return 1;
+        }
+
+        return first < second ? -1 : 1;
+    }
+
     /** Neutral first, then alphabetical, so the key authority heads the table. */
     public static compareCultures(first: string, second: string): number {
         if (first.length === 0 || second.length === 0) {

--- a/src/resxGroup.ts
+++ b/src/resxGroup.ts
@@ -2,27 +2,32 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { emptyString } from "./constants";
 import { ResxFileName } from "./resxFileName";
+import { ResxGroupFile } from "./resxGroupFile";
 
 const notAResxFile = (fileName: string) => `${fileName} is not a resx file`;
 
 /**
  * Every culture variant of one resource - `Foo.resx`, `Foo.de.resx`,
- * `Foo.fr.resx` - resolved from any one of them.
+ * `Foo.fr.resx` - resolved from any one of them. Names are matched
+ * case-insensitively; see {@link ResxFileName.sameBaseName}.
  */
 export class ResxGroup {
+    /** The neutral file's spelling when there is one, since it is the key authority. */
     public readonly baseName: string;
+
     public readonly directory: vscode.Uri;
 
     /** Neutral first, then alphabetical. */
     public readonly cultures: string[];
 
-    private readonly filesByCulture: Map<string, vscode.Uri>;
+    /** Keyed by {@link ResxFileName.cultureKey}, not by the culture as spelled. */
+    private readonly filesByCulture: Map<string, ResxGroupFile>;
 
-    private constructor(baseName: string, directory: vscode.Uri, filesByCulture: Map<string, vscode.Uri>) {
+    private constructor(baseName: string, directory: vscode.Uri, filesByCulture: Map<string, ResxGroupFile>) {
         this.baseName = baseName;
         this.directory = directory;
         this.filesByCulture = filesByCulture;
-        this.cultures = Array.from(filesByCulture.keys()).sort(ResxFileName.compareCultures);
+        this.cultures = Array.from(filesByCulture.values(), file => file.culture).sort(ResxFileName.compareCultures);
     }
 
     /**
@@ -36,6 +41,7 @@ export class ResxGroup {
         }
 
         const directory = uri.with({ path: path.posix.dirname(uri.path) });
+        const siblings = await ResxGroup.findSiblings(directory, parsed.baseName, fileName);
 
         /*
          * A dotted segment only names a culture if the neutral file is actually
@@ -43,43 +49,85 @@ export class ResxGroup {
          * as the culture "App" of a resource "My" that does not exist, and the
          * panel would go looking for siblings of a made up base name.
          */
-        const neutralUri = vscode.Uri.joinPath(directory, ResxFileName.toFileName(parsed.baseName, emptyString));
-        if (parsed.culture.length > 0 && await ResxGroup.exists(neutralUri) === false) {
+        if (parsed.culture.length > 0 && await ResxGroup.hasNeutral(siblings, directory, parsed.baseName) === false) {
             const standalone = ResxFileName.neutral(`${parsed.baseName}.${parsed.culture}`);
-            return new ResxGroup(standalone.baseName, directory, new Map([[standalone.culture, uri]]));
+            const only = new Map([[ResxFileName.cultureKey(standalone.culture), new ResxGroupFile(standalone, uri)]]);
+            return new ResxGroup(standalone.baseName, directory, only);
         }
 
-        const filesByCulture = new Map<string, vscode.Uri>();
+        // The file the command was invoked on belongs even if the listing failed.
+        siblings.set(ResxFileName.cultureKey(parsed.culture), new ResxGroupFile(parsed, uri));
+
+        return new ResxGroup(ResxGroup.neutralOf(siblings)?.name.baseName ?? parsed.baseName, directory, siblings);
+    }
+
+    public uriFor(culture: string): vscode.Uri | undefined {
+        return this.filesByCulture.get(ResxFileName.cultureKey(culture))?.uri;
+    }
+
+    /** The name on disk, which case folding means is not always the group's own spelling. */
+    public fileNameFor(culture: string): string {
+        return this.filesByCulture.get(ResxFileName.cultureKey(culture))?.fileName
+            ?? ResxFileName.toFileName(this.baseName, culture);
+    }
+
+    /**
+     * A file that resolves back to this same group - the neutral one, since the
+     * cultures sort with it first. The panel persists it for restore.
+     */
+    public get anchorUri(): vscode.Uri | undefined {
+        return this.uriFor(this.cultures[0]);
+    }
+
+    /**
+     * Identifies the group, so one resource never opens two panels. Folded:
+     * `Resources.de.resx` and `resources.resx` resolve to the same group.
+     */
+    public get key(): string {
+        return vscode.Uri.joinPath(this.directory, this.baseName.toLowerCase()).toString();
+    }
+
+    /** The variants of one resource in `directory`, keyed by culture. */
+    private static async findSiblings(directory: vscode.Uri,
+                                      baseName: string,
+                                      resolvedFrom: string): Promise<Map<string, ResxGroupFile>> {
+        const siblings = new Map<string, ResxGroupFile>();
+
         for (const [entryName, fileType] of await ResxGroup.readDirectory(directory)) {
             if ((fileType & vscode.FileType.File) === 0) {
                 continue;
             }
 
             const sibling = ResxFileName.parse(entryName);
-            if (sibling === undefined || sibling.baseName !== parsed.baseName) {
+            if (sibling === undefined || ResxFileName.sameBaseName(sibling.baseName, baseName) === false) {
                 continue;
             }
 
-            filesByCulture.set(sibling.culture, vscode.Uri.joinPath(directory, entryName));
+            const cultureKey = ResxFileName.cultureKey(sibling.culture);
+            const chosen = siblings.get(cultureKey);
+            if (chosen !== undefined && ResxFileName.compareSpellings(entryName, chosen.fileName, resolvedFrom) > 0) {
+                continue;
+            }
+
+            siblings.set(cultureKey, new ResxGroupFile(sibling, vscode.Uri.joinPath(directory, entryName)));
         }
 
-        // The file the command was invoked on belongs even if the listing failed.
-        filesByCulture.set(parsed.culture, uri);
-
-        return new ResxGroup(parsed.baseName, directory, filesByCulture);
+        return siblings;
     }
 
-    public uriFor(culture: string): vscode.Uri | undefined {
-        return this.filesByCulture.get(culture);
+    /* The listing answers alike everywhere; `fs.stat` only when it failed. */
+    private static async hasNeutral(siblings: Map<string, ResxGroupFile>,
+                                    directory: vscode.Uri,
+                                    baseName: string): Promise<boolean> {
+        if (siblings.size > 0) {
+            return ResxGroup.neutralOf(siblings) !== undefined;
+        }
+
+        return await ResxGroup.exists(vscode.Uri.joinPath(directory, ResxFileName.toFileName(baseName, emptyString)));
     }
 
-    public fileNameFor(culture: string): string {
-        return ResxFileName.toFileName(this.baseName, culture);
-    }
-
-    /** Identifies the group, so one resource never opens two panels. */
-    public get key(): string {
-        return vscode.Uri.joinPath(this.directory, this.baseName).toString();
+    private static neutralOf(siblings: Map<string, ResxGroupFile>): ResxGroupFile | undefined {
+        return siblings.get(ResxFileName.cultureKey(emptyString));
     }
 
     private static async exists(uri: vscode.Uri): Promise<boolean> {

--- a/src/resxGroupFile.ts
+++ b/src/resxGroupFile.ts
@@ -1,0 +1,23 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import type { ResxFileName } from "./resxFileName";
+
+/** One culture's file within a {@link ResxGroup}: its parsed name and its uri. */
+export class ResxGroupFile {
+    public readonly name: ResxFileName;
+    public readonly uri: vscode.Uri;
+
+    constructor(name: ResxFileName, uri: vscode.Uri) {
+        this.name = name;
+        this.uri = uri;
+    }
+
+    public get culture(): string {
+        return this.name.culture;
+    }
+
+    /* Off the uri, not the group's base name: case folding means they can differ. */
+    public get fileName(): string {
+        return path.posix.basename(this.uri.path);
+    }
+}

--- a/src/settingKey.ts
+++ b/src/settingKey.ts
@@ -1,0 +1,7 @@
+/** The setting names under `resxpress.configuration`; {@link Settings} holds their values. */
+export class SettingKey {
+    public static readonly generateStronglyTypedResourceClassOnSave = "generateStronglyTypedResourceClassOnSave";
+    public static readonly useFileScopedNamespace = "useFileScopedNamespace";
+    public static readonly indentSpaceLength = "indentSpaceLength";
+    public static readonly enableLocalLogs = "enableLocalLogs";
+}

--- a/src/test/combinedResx.test.ts
+++ b/src/test/combinedResx.test.ts
@@ -39,6 +39,30 @@ test("a dotted segment that is not a culture stays part of the base name", () =>
     assert.equal(ResxFileName.parse("notes.txt"), undefined);
 });
 
+test("base names match whatever case the filesystem stored them in", () => {
+    // fs.stat is case-insensitive on macOS and Windows, so the scan has to agree with it.
+    assert.equal(ResxFileName.sameBaseName("Resources", "resources"), true);
+    assert.equal(ResxFileName.sameBaseName("My.App", "MY.APP"), true);
+    assert.equal(ResxFileName.sameBaseName("Resources", "Resource"), false);
+});
+
+test("one culture is one column however its file spells it", () => {
+    assert.equal(ResxFileName.cultureKey("fr-CA"), "fr-ca");
+    assert.equal(ResxFileName.cultureKey(neutral), neutral);
+});
+
+test("the file the group was resolved from settles two spellings of one name", () => {
+    const resolvedFrom = "Resources.de.resx";
+
+    assert.ok(ResxFileName.compareSpellings("Resources.de.resx", "resources.de.resx", resolvedFrom) < 0);
+    assert.ok(ResxFileName.compareSpellings("resources.de.resx", "Resources.de.resx", resolvedFrom) > 0);
+    assert.equal(ResxFileName.compareSpellings("Resources.de.resx", "Resources.de.resx", resolvedFrom), 0);
+
+    // Neither is the file we came in on, so ordinal order decides rather than the listing's.
+    assert.ok(ResxFileName.compareSpellings("Resources.fr-CA.resx", "Resources.fr-ca.resx", resolvedFrom) < 0);
+    assert.ok(ResxFileName.compareSpellings("Resources.fr-ca.resx", "Resources.fr-CA.resx", resolvedFrom) > 0);
+});
+
 test("the neutral file sorts ahead of every culture", () => {
     const cultures = ["fr", "de", neutral, "pt-BR", "de-AT"];
     assert.deepEqual(cultures.sort(ResxFileName.compareCultures), [neutral, "de", "de-AT", "fr", "pt-BR"]);

--- a/src/webpanelMessageKind.ts
+++ b/src/webpanelMessageKind.ts
@@ -8,6 +8,7 @@ export enum WebpanelPostMessageKind {
     NewNamespace = "new-namespace",
     SortByKeys = "sort-by-keys",
     UpdateCombinedPanel = "update-combined-panel",
+    CombinedPanelIdentity = "combined-panel-identity",
     TriggerCombinedUpdate = "trigger-combined-update",
     SaveAll = "save-all",
     OpenAllLanguages = "open-all-languages"


### PR DESCRIPTION
- Registered a `WebviewPanelSerializer`, so a reload no longer leaves a dead All Languages tab.
- Matched sibling base names case-insensitively, which was silently dropping the Default column.
- Guarded `hasCultureSiblings` with a generation token so overlapping listings cannot leave it stale.
- Also fixed Tab parking cells under the sticky Key column, picked up new culture files without reopening, added the explorer entry, and cleared all lint warnings.