### PR TITLE
Deprecated indentSpaceLength in favour of the editor's own indent settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+- **Deprecated `resxpress.configuration.indentSpaceLength`**; it will be removed in a future
+  version. The fallback indent now comes from `editor.insertSpaces` and `editor.tabSize` for
+  the file. A value you have set explicitly is still honoured.
+- **Create Resx File** now indents the way your editor does - a tab, or `editor.tabSize`
+  spaces - instead of always a tab. Existing files keep their own indentation.
+
 ## 7.9.0 - 1-Sep-2026
 
 - Package updates.

--- a/README.md
+++ b/README.md
@@ -115,10 +115,18 @@ Default: **`true`**
 **true**: File scoped namespaces.  
 **false**: Block scoped namespaces.  
 
-1. `indentSpaceLength`: Indent space length for resx xml, used only when a file's own indentation
-cannot be detected. A file that is already indented keeps its own style.
-Default: **4**.
+1. `indentSpaceLength`: **Deprecated, and will be removed in a future version** — use
+`editor.insertSpaces` and `editor.tabSize` instead.
+It is still honoured wherever it is explicitly set.
 Options: **2, 4, 8**.
+
+### Indentation
+
+A resx that is already indented keeps its own style, tabs included: ResXpress copies whatever
+the file uses, so a one-character edit stays a one-character edit in the diff. Indentation is
+only _chosen_ where there is nothing to copy — a new file made with **Create Resx File**, or a
+file with no indentation at all — and that choice follows your editor: a tab when
+`editor.insertSpaces` is off, otherwise `editor.tabSize` spaces.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
                             4,
                             8
                         ],
-                        "markdownDescription": "No. of spaces for resx xml, used only when a file's own indentation cannot be detected. A file that is already indented keeps its own style. Default: *4*"
+                        "markdownDescription": "No. of spaces for resx xml, used only when a file's own indentation cannot be detected. A file that is already indented keeps its own style. Default: *4*",
+                        "markdownDeprecationMessage": "**Deprecated**: use `#editor.insertSpaces#` and `#editor.tabSize#` instead, which ResXpress now reads per file. A file that is already indented still keeps its own style. This setting is honoured while it is set, and will be removed in a future version."
                     },
                     "resxpress.configuration.enableLocalLogs": {
                         "type": "boolean",

--- a/src/combinedResxPanel.ts
+++ b/src/combinedResxPanel.ts
@@ -5,6 +5,7 @@ import type { CombinedEntry } from "./combinedEntry";
 import type { CombinedPayload } from "./combinedPayload";
 import { CombinedResx } from "./combinedResx";
 import { Constants } from "./constants";
+import { IndentPreference } from "./indentPreference";
 import { readInlineIcon } from "./inlineSvgIcon";
 import { Logger } from "./logger";
 import { nameof } from "./nameof";
@@ -13,7 +14,6 @@ import type { ResxEntry } from "./resxEntry";
 import { ResxFile } from "./resxFile";
 import { ResxFileName } from "./resxFileName";
 import { ResxGroup } from "./resxGroup";
-import { Settings } from "./settings";
 import { getNonce } from "./util";
 import { WebpanelPostMessageKind } from "./webpanelMessageKind";
 import { WebpanelPostMessage } from "./webpanelPostMessage";
@@ -373,7 +373,7 @@ export class CombinedResxPanel {
 
     private static readEntries(document: vscode.TextDocument): ResxEntry[] | undefined {
         try {
-            return ResxFile.parse(document.getText(), Settings.indentSpaceLength).entries;
+            return ResxFile.parse(document.getText(), IndentPreference.resolve(document.uri)).entries;
         }
         catch (error) {
             if (error instanceof Error) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,8 @@ import * as path from "path";
 import { ResxEditorProvider } from "./resxEditorProvider";
 import { NotificationService } from "./notificationService";
 import { FileHelper } from "./fileHelper";
+import { IndentPreference } from "./indentPreference";
+import { createResxTemplate } from "./resxTemplate";
 import { TextInputBoxOptions } from "./textInputBoxOptions";
 import { CommandId } from "./commandId";
 import { Constants, emptyString } from "./constants";
@@ -206,7 +208,6 @@ function loadConfiguration() {
 	let resxConfig = vscode.workspace.getConfiguration(`${Constants.resxpress}.${Constants.configuration}`);
 	Settings.shouldGenerateStronglyTypedResourceClassOnSave = resxConfig.get<boolean>(SettingKey.generateStronglyTypedResourceClassOnSave) ?? false;
 	Settings.shouldUseFileScopedNamespace = resxConfig.get<boolean>(SettingKey.useFileScopedNamespace) ?? true;
-	Settings.indentSpaceLength = resxConfig.get<number>(SettingKey.indentSpaceLength) ?? 4;
 	Settings.enableLocalLogs = resxConfig.get<boolean>(SettingKey.enableLocalLogs) ?? false;
 	Logger.instance.setIsEnabled(Settings.enableLocalLogs);
 }
@@ -258,7 +259,7 @@ export async function runResGenAsync(document: vscode.TextDocument): Promise<voi
 
 	let documentText = document.getText();
 	if (documentText.length > 0) {
-		const entries = ResxFile.parse(documentText, Settings.indentSpaceLength).entries;
+		const entries = ResxFile.parse(documentText, IndentPreference.resolve(document.uri)).entries;
 		var resourceCSharpClassText = emptyString;
 		let accessModifier = "public";
 		let workspacePath = FileHelper.getDirectory(document);
@@ -342,7 +343,8 @@ async function newPreview() {
 	var text = vscode.window.activeTextEditor?.document?.getText() ?? emptyString;
 	var currentFileName = vscode.window.activeTextEditor?.document.fileName;
 	if (currentFileName) {
-		await displayJsonInHtml(ResxFile.parse(text, Settings.indentSpaceLength).entries, currentFileName);
+		const indent = IndentPreference.resolve(vscode.window.activeTextEditor?.document.uri);
+		await displayJsonInHtml(ResxFile.parse(text, indent).entries, currentFileName);
 	}
 }
 
@@ -359,7 +361,8 @@ async function displayAsMarkdown() {
 				return;
 			}
 			const documentText = vscode.window.activeTextEditor?.document?.getText() ?? emptyString;
-			const entries = ResxFile.parse(documentText, Settings.indentSpaceLength).entries;
+			const indent = IndentPreference.resolve(vscode.window.activeTextEditor?.document.uri);
+			const entries = ResxFile.parse(documentText, indent).entries;
 			var currentFileName = vscode.window.activeTextEditor?.document.fileName;
 			if (currentFileName) {
 				var fileNameNoExt = vscode.window.activeTextEditor?.document.fileName.substring(
@@ -538,22 +541,8 @@ async function createResxFile(uri: vscode.Uri | null) {
 			Logger.instance.info(`Filename to be created: ${resxFilePath}`);
 			// create a Uri for a file to be created
 			const resxFileUri = vscode.Uri.file(resxFilePath);
-			const content = `<?xml version="1.0" encoding="utf-8"?>
-<root>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>2.0</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<!--Data-->
-</root>`;
+			// Detection preserves this indent from now on, so it has to match the user's editor.
+			const content = createResxTemplate(IndentPreference.resolve(resxFileUri));
 
 			let encoder = new TextEncoder();
 			let uInt8Array = encoder.encode(content);

--- a/src/indentPreference.ts
+++ b/src/indentPreference.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+import { Constants } from "./constants";
+import { SettingKey } from "./settingKey";
+
+const defaultTabSize = 4;
+const tab = "\t";
+
+/** The indent for a resx with none of its own to copy: a new file, or one with no indentation at all. */
+export class IndentPreference {
+    /** @param uri the resx being written, so a folder or language override applies. */
+    public static resolve(uri: vscode.Uri | undefined): string {
+        const explicitSpaceLength = IndentPreference.explicitSpaceLength(uri);
+        if (explicitSpaceLength !== undefined) {
+            return " ".repeat(explicitSpaceLength);
+        }
+
+        const editorConfiguration = vscode.workspace.getConfiguration(Constants.editor, uri);
+        if (editorConfiguration.get<boolean>("insertSpaces") === false) {
+            return tab;
+        }
+
+        return " ".repeat(editorConfiguration.get<number>("tabSize") ?? defaultTabSize);
+    }
+
+    /*
+     * Deprecated, but still honoured where a user set it deliberately. inspect() rather
+     * than get(), because get() returns the contributed default of 4 and would outrank
+     * the editor for everybody. Delete this when the setting goes.
+     */
+    private static explicitSpaceLength(uri: vscode.Uri | undefined): number | undefined {
+        const inspected = vscode.workspace
+                                .getConfiguration(`${Constants.resxpress}.${Constants.configuration}`, uri)
+                                .inspect<number>(SettingKey.indentSpaceLength);
+
+        return inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue;
+    }
+}

--- a/src/resxDocumentWriter.ts
+++ b/src/resxDocumentWriter.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 import { emptyString } from "./constants";
+import { IndentPreference } from "./indentPreference";
 import { Logger } from "./logger";
 import { computeMinimalTextEdit } from "./minimalTextEdit";
 import { nameof } from "./nameof";
 import type { ResxEntry } from "./resxEntry";
 import { ResxFile } from "./resxFile";
-import { Settings } from "./settings";
 
 /**
  * Writes resx changes back to a document as the smallest edit that produces
@@ -23,7 +23,7 @@ export class ResxDocumentWriter {
     private static async rewrite(document: vscode.TextDocument, change: (resxFile: ResxFile) => void): Promise<boolean> {
         try {
             const currentText = document.getText();
-            const resxFile = ResxFile.parse(currentText, Settings.indentSpaceLength);
+            const resxFile = ResxFile.parse(currentText, IndentPreference.resolve(document.uri));
             change(resxFile);
             return await ResxDocumentWriter.write(document, currentText, resxFile.toXml());
         }

--- a/src/resxEditorProvider.ts
+++ b/src/resxEditorProvider.ts
@@ -3,13 +3,13 @@ import { CommandId } from "./commandId";
 import { Constants, emptyString } from "./constants";
 import { setNewNamespace, sortByKeys } from "./extension";
 import { FileHelper } from "./fileHelper";
+import { IndentPreference } from "./indentPreference";
 import { Logger } from "./logger";
 import { ResxDocumentWriter } from "./resxDocumentWriter";
 import { ResxEditor } from "./resxEditor";
 import type { ResxEntry } from "./resxEntry";
 import { ResxFile } from "./resxFile";
 import { ResxGroup } from "./resxGroup";
-import { Settings } from "./settings";
 import { WebpanelPostMessageKind } from "./webpanelMessageKind";
 import { WebpanelPostMessage } from "./webpanelPostMessage";
 
@@ -108,7 +108,7 @@ export class ResxEditorProvider implements vscode.CustomTextEditorProvider {
 
         function updateWebview() {
             try {
-                const entries = ResxFile.parse(document.getText(), Settings.indentSpaceLength).entries;
+                const entries = ResxFile.parse(document.getText(), IndentPreference.resolve(document.uri)).entries;
                 webviewPanel.webview.postMessage(new WebpanelPostMessage(WebpanelPostMessageKind.UpdateWebPanel, JSON.stringify(entries)));
             }
             catch (error) {

--- a/src/resxFile.ts
+++ b/src/resxFile.ts
@@ -28,11 +28,12 @@ export class ResxFile {
     }
 
     /**
+     * @param fallbackIndent used only when the text has no indentation to copy.
      * @throws when the text is not well-formed XML.
      */
-    public static parse(text: string, fallbackIndentLength: number = defaultIndentLength): ResxFile {
+    public static parse(text: string, fallbackIndent: string | number = defaultIndentLength): ResxFile {
         const document = xmljs.xml2js(text) as xmljs.Element;
-        return new ResxFile(document, ResxFormat.detect(text, fallbackIndentLength));
+        return new ResxFile(document, ResxFormat.detect(text, fallbackIndent));
     }
 
     public get entries(): ResxEntry[] {

--- a/src/resxFormat.ts
+++ b/src/resxFormat.ts
@@ -26,8 +26,8 @@ export class ResxFormat {
         this.trailingWhitespace = trailingWhitespace;
     }
 
-    public static detect(text: string, fallbackIndentLength: number): ResxFormat {
-        return new ResxFormat(detectIndent(text) ?? fallbackIndentLength,
+    public static detect(text: string, fallbackIndent: string | number): ResxFormat {
+        return new ResxFormat(detectIndent(text) ?? fallbackIndent,
                               text.includes(carriageReturnLineFeed) ? carriageReturnLineFeed : lineFeed,
                               detectSpaceBeforeSelfClosingSlash(text),
                               detectTrailingWhitespace(text));

--- a/src/resxTemplate.ts
+++ b/src/resxTemplate.ts
@@ -1,0 +1,18 @@
+const resourceHeaders: ReadonlyArray<readonly [string, string]> = [
+    ["resmimetype", "text/microsoft-resx"],
+    ["version", "2.0"],
+    ["reader", "System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"],
+    ["writer", "System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"]
+];
+
+/**
+ * The contents of a newly created resx. `<!--Data-->` is the marker the editor
+ * adds the first entry below, and the file deliberately ends without a trailing
+ * newline so a later round trip does not grow one.
+ */
+export function createResxTemplate(indent: string): string {
+    const headers = resourceHeaders.map(([name, value]) =>
+        `${indent}<resheader name="${name}">\n${indent}${indent}<value>${value}</value>\n${indent}</resheader>`);
+
+    return `<?xml version="1.0" encoding="utf-8"?>\n<root>\n${headers.join("\n")}\n${indent}<!--Data-->\n</root>`;
+}

--- a/src/settingKey.ts
+++ b/src/settingKey.ts
@@ -2,6 +2,7 @@
 export class SettingKey {
     public static readonly generateStronglyTypedResourceClassOnSave = "generateStronglyTypedResourceClassOnSave";
     public static readonly useFileScopedNamespace = "useFileScopedNamespace";
+    /** @deprecated Superseded by `editor.tabSize` and `editor.insertSpaces`; to be removed in a future version. */
     public static readonly indentSpaceLength = "indentSpaceLength";
     public static readonly enableLocalLogs = "enableLocalLogs";
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,4 @@
 export class Settings {
-    public static indentSpaceLength = 4;
     public static shouldGenerateStronglyTypedResourceClassOnSave = false;
     public static shouldUseFileScopedNamespace = true;
     public static enableLocalLogs = false;

--- a/src/test/resxRoundTrip.test.ts
+++ b/src/test/resxRoundTrip.test.ts
@@ -102,9 +102,10 @@ test("a new entry is appended after the last data element, not at the end of the
 
 test("the first entry added to a brand new file lands below the Data marker", () => {
     /*
-     * Mirrors what createResxFile writes: tab indented, no trailing newline, and
-     * <!--Data--> as the last child, so there is no existing <data> element to append
-     * after. Every other add test starts from a file that already has entries.
+     * An empty file's shape: no trailing newline and <!--Data--> as the last child, so
+     * there is no existing <data> element to append after. Every other add test starts
+     * from a file that already has entries. Tab indented, as Create Resx File writes
+     * it when editor.insertSpaces is off.
      */
     const created = `<?xml version="1.0" encoding="utf-8"?>\n<root>\n\t<resheader name="resmimetype">\n\t\t<value>text/microsoft-resx</value>\n\t</resheader>\n\t<!--Data-->\n</root>`;
     const resxFile = ResxFile.parse(created, 4);
@@ -119,14 +120,14 @@ test("the first entry added to a brand new file lands below the Data marker", ()
     assert.ok(xml.endsWith("</root>"), "the template has no trailing newline and does not grow one");
 });
 
-test("indentation comes from the file, not from the setting", () => {
+test("indentation comes from the file, not from the fallback", () => {
     assert.ok(ResxFile.parse(fixture, 8).toXml().includes(`\n  <data name="Padded"`));
 
     const tabbed = `<root>\n\t<data name="A" xml:space="preserve">\n\t\t<value>a</value>\n\t</data>\n</root>\n`;
     assert.equal(ResxFile.parse(tabbed, 4).toXml(), tabbed);
 });
 
-test("the setting still decides indentation when the file has none to copy", () => {
+test("the fallback decides indentation when the file has none to copy", () => {
     const unformatted = `<root><data name="A" xml:space="preserve"><value>a</value></data></root>`;
     assert.ok(ResxFile.parse(unformatted, 2).toXml().includes(`\n  <data name="A"`));
 });

--- a/src/test/resxTemplate.test.ts
+++ b/src/test/resxTemplate.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ResxFile } from "../resxFile.ts";
+import { createResxTemplate } from "../resxTemplate.ts";
+
+test("a created file is indented with the unit it was given", () => {
+    const twoSpaces = createResxTemplate("  ");
+    assert.ok(twoSpaces.includes(`\n  <resheader name="resmimetype">\n    <value>text/microsoft-resx</value>\n  </resheader>`));
+
+    const fourSpaces = createResxTemplate("    ");
+    assert.ok(fourSpaces.includes(`\n    <resheader name="resmimetype">\n        <value>text/microsoft-resx</value>\n    </resheader>`));
+
+    const tabbed = createResxTemplate("\t");
+    assert.ok(tabbed.includes(`\n\t<resheader name="resmimetype">\n\t\t<value>text/microsoft-resx</value>\n\t</resheader>`));
+
+    assert.equal(twoSpaces.includes("\t"), false, "a space indented file contains no tab");
+});
+
+// Creation picks the indent and detection preserves it, so a new file's first edit
+// must not rewrite every line of it.
+const createdIndents: ReadonlyArray<readonly [string, string]> = [
+    ["2 spaces", "  "],
+    ["4 spaces", "    "],
+    ["8 spaces", "        "],
+    ["a tab", "\t"]
+];
+
+for (const [label, indent] of createdIndents) {
+    test(`a file created with ${label} round trips byte identically`, () => {
+        const template = createResxTemplate(indent);
+        assert.equal(ResxFile.parse(template).toXml(), template);
+    });
+
+    test(`the first entry added to a file created with ${label} copies that indent`, () => {
+        const resxFile = ResxFile.parse(createResxTemplate(indent));
+        assert.deepEqual(resxFile.entries, []);
+
+        resxFile.applyEntries([{ key: "Hello", value: "World", comment: "first one" }]);
+        const xml = resxFile.toXml();
+
+        assert.ok(xml.indexOf("<!--Data-->") < xml.indexOf("<data "), "the marker still introduces the data block");
+        assert.ok(
+            xml.includes(`${indent}<data name="Hello" xml:space="preserve">\n${indent}${indent}<value>World</value>`),
+            "the entry copies the template's indent"
+        );
+    });
+}
+
+test("the template ends without a trailing newline, and adding an entry does not grow one", () => {
+    const template = createResxTemplate("    ");
+    assert.ok(template.endsWith("</root>"));
+
+    const resxFile = ResxFile.parse(template);
+    resxFile.applyEntries([{ key: "Hello", value: "World" }]);
+    assert.ok(resxFile.toXml().endsWith("</root>"));
+});


### PR DESCRIPTION
Deprecated indentSpaceLength in favour of the editor's own indent settings

- Create Resx File now indents the way the editor does: a tab when
  editor.insertSpaces is off, otherwise editor.tabSize spaces. It used to
  write a hardcoded tab template regardless of any setting.
- A file with no indentation to copy gets the same indent. A file that is
  already indented still keeps its own.
- indentSpaceLength is deprecated and will be removed in a future version.
  A value the user set explicitly still wins until then.
- Added IndentPreference as the single source of that indent, and
  resxTemplate for the new-file template; Settings.indentSpaceLength is gone.
- Tests pin that a created file round-trips byte-identically with 2, 4 and 8
  spaces and with a tab.